### PR TITLE
Another bug in BEP scaling for input parameters?

### DIFF
--- a/catmap/scalers/generalized_linear_scaler.py
+++ b/catmap/scalers/generalized_linear_scaler.py
@@ -229,7 +229,16 @@ class GeneralizedLinearScaler(ScalerBase):
                         coeff_vals.append(m*abs(ck))
                     else:
                         coeff_vals.append(ck)
-                coeff_vals.append(b)
+                offset = 0.
+                if params and len(params) == 2:
+                    for gas in self.gas_names:
+                        if gas in IS:
+                            offset += (1.-m)*self.species_definitions[gas]['formation_energy']
+                        elif gas in FS:
+                            offset += m*self.species_definitions[gas]['formation_energy']
+                        else:
+                            continue
+                coeff_vals.append(b+offset)
             else:
                 coeff_vals = [m*ci for ci in coeffs] + [b]
 


### PR DESCRIPTION
It seems gas phase formation energies were not taken into account in BEP scaling for input parameters.
I added these to the b value, since they are independent of descriptor values.
I guess this does not affect BEP parameters obtained from linear regression. Here the gas phase energies must be taken into account in IS_totals or FS_totals?
Please check!
